### PR TITLE
Update datasketch commit to use rust_pyhash

### DIFF
--- a/deduplication/README.md
+++ b/deduplication/README.md
@@ -1,4 +1,13 @@
 # Install
+
+This package requires `rust` and `cargo`. The recommended way to install these dependencies is using [`rustup`](https://rustup.rs/):
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Then, to install the python package you can use pip:
+
 ```bash
 git clone https://github.com/TPC-AI/data-general-text-code-web.git
 cd data-general-text-code-web/

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,7 @@ setup(
         'numpy>=1.11',
         'scipy>=1.0.0',
         'redis>=2.10.0',
-        'datasketch @ git+https://github.com/123epsilon/datasketch.git@060a32b4b4a2272d77480dd633a1bf770678ba49',
-        'pybloomfiltermmap3==0.5.7',
+        'datasketch @ git+https://github.com/123epsilon/datasketch.git@8f4b34f604e3d26369a50ab731b4948c0e04eb5a',
         'tqdm>=4.60.0',
     ]
 )


### PR DESCRIPTION
The install of rust_pyhash and pybloomfilter are handled by datasketch. We can still `pip install .` as far as users of this repository are concerned. This change requires that users have Cargo installed.